### PR TITLE
Support/wagtail 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Update for Wagtail 5.1
+
+
 0.1 (2023-07-27)
 ----------------
 

--- a/wagtail_webstories/templates/wagtail_webstories/admin/import.html
+++ b/wagtail_webstories/templates/wagtail_webstories/admin/import.html
@@ -27,7 +27,7 @@
                     {% if field.is_hidden %}
                         {{ field }}
                     {% else %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                        {% include "wagtailadmin/shared/field.html" with field=field %}
                     {% endif %}
                 {% endfor %}
                 <li><input type="submit" value="{% trans 'Import' %}" class="button" /></li>


### PR DESCRIPTION
# This updated the package for Wagtail v5.1 support.

The current release: [0.1](https://pypi.org/project/wagtail-webstories/) will work fine for Wagtail v5.1

## Note this PR is to the main-latest branch.

The maintainers repo has a new release for v5.0 which doesn't include any of our previous work so our main is out of sync with the maintainers main. I therefore created a new branch [main-latest](https://github.com/torchbox-forks/wagtail-webstories/tree/main-latest) to use for this work.

Once code reviewed we should be able to merge this PR to our main-latest branch and rename this branch to main. We only use this package on torchbox.com so at the next upgrade (5.1) we can adjust that site to use the latest release at that time.